### PR TITLE
Added support to handle exceptions

### DIFF
--- a/src/CoroutineScheduler/PublicAPI.Unshipped.txt
+++ b/src/CoroutineScheduler/PublicAPI.Unshipped.txt
@@ -7,4 +7,11 @@ CoroutineScheduler.Scheduler
 CoroutineScheduler.Scheduler.Resume() -> void
 CoroutineScheduler.Scheduler.Scheduler() -> void
 CoroutineScheduler.Scheduler.SpawnTask(System.Func<System.Threading.Tasks.Task!>! func) -> System.Threading.Tasks.Task!
+CoroutineScheduler.Scheduler.UnhandledException -> System.EventHandler<CoroutineScheduler.UnhandledExceptionEventArgs!>?
 CoroutineScheduler.Scheduler.Yield() -> CoroutineScheduler.YieldTask
+CoroutineScheduler.UnhandledExceptionEventArgs
+CoroutineScheduler.UnhandledExceptionEventArgs.Exception.get -> System.Exception!
+CoroutineScheduler.UnhandledExceptionEventArgs.Rethrow.get -> bool
+CoroutineScheduler.UnhandledExceptionEventArgs.Rethrow.set -> void
+CoroutineScheduler.UnhandledExceptionEventArgs.RethrowAsync.get -> bool
+CoroutineScheduler.UnhandledExceptionEventArgs.RethrowAsync.set -> void


### PR DESCRIPTION
Does not touch the interface, only the fully qualified type can access the exception handler event.

Subscribers can prevent the exception from being rethrown in the case the application wishes to either ignore the exception, or will handle it in another way.