### PR TITLE
Added AsyncSignal

### DIFF
--- a/CoroutineScheduler.sln
+++ b/CoroutineScheduler.sln
@@ -14,7 +14,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
 		CONTRIBUTING.md = CONTRIBUTING.md
-		src\CoroutineScheduler.Core\CoroutineScheduler.Core.csproj = src\CoroutineScheduler.Core\CoroutineScheduler.Core.csproj
 		Directory.Build.props = Directory.Build.props
 		LICENSE = LICENSE
 		NuGet.Config = NuGet.Config

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,6 +48,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <VerliteEnableShadowRepo>true</VerliteEnableShadowRepo>
+    <VerliteMinimumVersion>0.4.0</VerliteMinimumVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Verlite.MsBuild" Version="2.5.0" PrivateAssets="All" />

--- a/src/CoroutineScheduler/AsyncSignal.cs
+++ b/src/CoroutineScheduler/AsyncSignal.cs
@@ -1,0 +1,199 @@
+#if DEBUG
+#define DEBUG_ASYNC
+#endif
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace CoroutineScheduler;
+
+/// <summary>
+/// Waits for a signal to be raised<br/>
+/// <br/>
+/// Note that this is a hybrid of a condition variable, a manual reset event, and an automatic reset event:<br/>
+/// - Condition variable takes a locked mutex to eliminate race conditions, atomically unlocking and waiting<br/>
+/// - Manual reset event requires the event be reset, and does not guarantee all current waiters have been resumed (non-deterministic)<br/>
+/// - AutoResetEvent will release one waiter in a non-deterministic fashion, and if no waiters, the next waiter will not block
+///   resolving the race condition present in the manual reset event <br/>
+/// <br/>
+/// To resolve the race condition in a manner similar to a condition variable, you may call Wait() early, then await the return value
+/// after you have completed your check in the case you need to wait:
+/// <code>
+///		// with a signal
+///		while (true)
+///		{
+///			var signalWaitTask = signal.Wait();
+///			// warning: does not provide exclusivity/thread-safety
+///			if (!queue.TryDeque(out var item))
+///				await signalWaitTask;
+///			Process(item);
+///		}
+///		// is equivalent to the following C++ with a condition var
+///		while (true)
+///		{
+///			std::unique_lock lock(queueMutex);
+///			while (queue.size() == 0)
+///				conditionVar.wait(lock);
+///			auto item = queue.pop_front();
+///			Process(item);
+///		}
+///	</code>
+/// </summary>
+public class AsyncSignal
+{
+	private readonly ConcurrentQueue<WorkItem> workQueue = new();
+	private volatile int currentToken;
+	private readonly object tokenLock = new object();
+
+	internal struct WorkItem
+	{
+		public Action Continuation { get; set; }
+		public ExecutionContext? Context { get; set; }
+	}
+
+	/// <summary>
+	/// Wait for the signal
+	/// </summary>
+	/// <returns>An awaitable that completes when <see cref="NotifyAll()"/> is called</returns>
+	public AsyncSignalTask Wait()
+	{
+		return new(this, currentToken);
+	}
+
+	/// <summary>
+	/// Complete all awaitables that are waiting for this signal
+	/// </summary>
+	/// <exception cref="InternalReleaseException"></exception>
+#if !DEBUG_ASYNC
+	[DebuggerNonUserCode]
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+	public void NotifyAll()
+	{
+		int alreadyQueuedCount;
+		lock (tokenLock)
+		{
+			Interlocked.Increment(ref currentToken);
+			alreadyQueuedCount = workQueue.Count;
+		}
+
+		while (alreadyQueuedCount > 0)
+		{
+			if (!workQueue.TryDequeue(out var workItem))
+				throw new InternalReleaseException("Failed to dequeue the next continuation.");
+
+			alreadyQueuedCount--;
+			Execute(workItem);
+		}
+	}
+
+	internal bool IsTokenCompleted(int token)
+	{
+		return currentToken != token;
+	}
+
+	internal void AddContinuation(int token, WorkItem item)
+	{
+		lock (tokenLock)
+		{
+			if (token == currentToken)
+			{
+				workQueue.Enqueue(item);
+				return;
+			}
+		}
+		Execute(item);
+	}
+
+	private static ContextCallback? Runner { get; set; }
+	private static void Execute(WorkItem item)
+	{
+		// cache this allocation
+		[DebuggerNonUserCode]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		static void executionContextRunner(object obj) => (obj as Action)!();
+		Runner ??= executionContextRunner!;
+
+		if (item.Context is null)
+			item.Continuation();
+		else
+			ExecutionContext.Run(item.Context, Runner, item.Continuation);
+	}
+}
+
+/// <summary>
+/// An awaitable that posts to the signal. Contains a token to resolve race conditions
+/// </summary>
+public readonly record struct AsyncSignalTask
+{
+	private AsyncSignal Signal { get; }
+	private int Token { get; }
+
+	internal AsyncSignalTask(
+		AsyncSignal signal,
+		int token)
+	{
+		Signal = signal;
+		Token = token;
+	}
+
+	/// <summary>
+	/// Get an awaiter for the current awaitable
+	/// </summary>
+	public AsyncSignalAwaiter GetAwaiter()
+	{
+		return new AsyncSignalAwaiter(Signal, Token);
+	}
+}
+
+/// <summary>
+/// <inheritdoc/>
+/// </summary>
+public readonly record struct AsyncSignalAwaiter : ICriticalNotifyCompletion
+{
+	private AsyncSignal Signal { get; }
+	private int Token { get; }
+
+	internal AsyncSignalAwaiter(AsyncSignal signal, int token)
+	{
+		Signal = signal;
+		Token = token;
+	}
+
+	/// <summary>
+	/// Whether or not the awaitable has completed
+	/// </summary>
+	public bool IsCompleted => Signal.IsTokenCompleted(Token);
+	/// <summary>
+	/// No op
+	/// </summary>
+	public void GetResult() { }
+
+#if !DEBUG_ASYNC
+	[DebuggerNonUserCode]
+#endif
+	void INotifyCompletion.OnCompleted(Action continuation)
+	{
+		Signal.AddContinuation(
+			Token,
+			new()
+			{
+				Continuation = continuation,
+				Context = ExecutionContext.Capture(),
+			});
+	}
+#if !DEBUG_ASYNC
+	[DebuggerNonUserCode]
+#endif
+	void ICriticalNotifyCompletion.UnsafeOnCompleted(Action continuation)
+	{
+		Signal.AddContinuation(
+			Token,
+			new()
+			{
+				Continuation = continuation,
+				Context = null,
+			});
+	}
+}

--- a/src/CoroutineScheduler/PublicAPI.Unshipped.txt
+++ b/src/CoroutineScheduler/PublicAPI.Unshipped.txt
@@ -1,4 +1,16 @@
 #nullable enable
+CoroutineScheduler.AsyncSignal
+CoroutineScheduler.AsyncSignal.AsyncSignal() -> void
+CoroutineScheduler.AsyncSignal.NotifyAll() -> void
+CoroutineScheduler.AsyncSignal.Wait() -> CoroutineScheduler.AsyncSignalTask
+CoroutineScheduler.AsyncSignalAwaitable
+CoroutineScheduler.AsyncSignalAwaitable.AsyncSignalAwaitable() -> void
+CoroutineScheduler.AsyncSignalAwaitable.GetAwaiter() -> CoroutineScheduler.AsyncSignalAwaiter
+CoroutineScheduler.AsyncSignalAwaitable.IsCompleted.get -> bool
+CoroutineScheduler.AsyncSignalAwaiter
+CoroutineScheduler.AsyncSignalAwaiter.AsyncSignalAwaiter() -> void
+CoroutineScheduler.AsyncSignalAwaiter.GetResult() -> void
+CoroutineScheduler.AsyncSignalAwaiter.IsCompleted.get -> bool
 CoroutineScheduler.InternalReleaseException
 CoroutineScheduler.InternalReleaseException.InternalReleaseException(string! message) -> void
 CoroutineScheduler.InternalReleaseException.InternalReleaseException(string! message, System.Exception! innerException) -> void

--- a/tests/UnitTests/AsyncSignalTests.cs
+++ b/tests/UnitTests/AsyncSignalTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using CoroutineScheduler;
+
+using Xunit;
+
+namespace UnitTests;
+
+public class AsyncSignalTests
+{
+	[Fact]
+	public void SimpleWaitingFunctional()
+	{
+		var signal = new AsyncSignal();
+
+		int x = 0;
+		async Task taskFunc()
+		{
+			x = 10;
+			await signal.Wait();
+			x = 20;
+			await signal.Wait();
+			x = 30;
+		};
+
+		var t = taskFunc();
+		x.Should().Be(10);
+		signal.NotifyAll();
+		x.Should().Be(20);
+		signal.NotifyAll();
+		x.Should().Be(30);
+	}
+
+	[Fact]
+	public void OldWaitsDontWait()
+	{
+		var signal = new AsyncSignal();
+
+		int x = 0;
+		async Task taskFunc()
+		{
+			x = 10;
+			var oldWait = signal.Wait();
+			await signal.Wait();
+			x = 20;
+			await oldWait;
+			x = 30;
+		};
+
+		var t = taskFunc();
+		x.Should().Be(10);
+		signal.NotifyAll();
+		x.Should().Be(30);
+	}
+}


### PR DESCRIPTION
This class operates very similarly to the scheduler, but is much more lightweight. Unlike the scheduler, this can be used in a similar manner to a condition variable where you can observe some changes, and then wait for further changes to the observable, but never having the race condition that is present if the IScheduler is used this way.

For example, the following code has a race condition bug where the read and the block are not atomic, and so if the state changes between the state read and the yield, the state update will be missed. In this case, the race condition window has been artificially increased to ~500ms:

```cs
while (true)
{
    StateCopy = Something.State;
    await Task.Delay(500);
    await Something.Scheduler.Yield();
}
```

But with the AsyncSignal, we can correctly handle this behavior and receive the new state update too by calling the Wait() before we read the state, and then later on. If the signal has been fired, then the subsequent `await waitTask` will be a no op:

```cs
while (true)
{
    var waitTask = Something.Signal.Wait();
    StateCopy = Something.State;
    await Task.Delay(500);
    await waitTask;
}
```

<!-- Please read CONTRIBUTING.md -->

High level of what was changed, possibly include why this approach was taken.

Are there any concerns or areas to be aware of regarding the approach taken or areas changed?

- [x] Tests added
- [x] Linked issue if exists
- [x] Updated documentation
