### PR TITLE
AsyncSignal: Fix bug where work items weren't being properly reset

### DIFF
--- a/src/CoroutineScheduler/Scheduler.cs
+++ b/src/CoroutineScheduler/Scheduler.cs
@@ -63,7 +63,11 @@ public sealed class Scheduler : IScheduler
 	private ContextCallback? Runner { get; set; }
 
 	private int? ResumingOnThread { get; set; }
-	private bool RequiresMarshalling => ResumingOnThread is null || ResumingOnThread.Value != Thread.CurrentThread.ManagedThreadId;
+	private bool RequiresMarshalling => ResumingOnThread switch
+	{
+		int resumingThread => resumingThread != Thread.CurrentThread.ManagedThreadId,
+		_ => true,
+	};
 
 	/// <summary>
 	/// Resume any tasks that are at the point of invocation are currently awaiting `Yield()`, and <br />


### PR DESCRIPTION
This caused them to throw "Dequeued work item somehow completed in back queue"